### PR TITLE
Option Convert IAC EOR/GA to new line und Räume ohne Namen

### DIFF
--- a/lua/unitopia/main/main.lua
+++ b/lua/unitopia/main/main.lua
@@ -129,7 +129,7 @@ function OnUnitopiaRoomInfo(message, rawData)
     local domain, room = info["domain"], info["name"]
     local matchingArea = nil
 
-    if room then
+    if room and room ~= 0 then
       -- Individual rooms take precedence over the city or domain
       room = room:lower()
 

--- a/worlds/unitopia.MCL
+++ b/worlds/unitopia.MCL
@@ -38,6 +38,7 @@
    confirm_before_replacing_typing="y"
    confirm_on_paste="y"
    confirm_on_send="y"
+   convert_ga_to_newline="y"
    default_trigger_sequence="100"
    default_alias_sequence="100"
    detect_pueblo="y"


### PR DESCRIPTION
Damit werden Prompts unter anderem beim Login, in den Einstellungen oder bei der Ausgabe mit more richtig angezeigt.